### PR TITLE
Addition: Write to file, add options as program arguments, clean code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -295,6 +295,11 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
     },
+    "array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q=="
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -903,6 +908,17 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "requires": {
         "delayed-stream": "~1.0.0"
+      }
+    },
+    "command-line-args": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.1.tgz",
+      "integrity": "sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==",
+      "requires": {
+        "array-back": "^3.0.1",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
       }
     },
     "commander": {
@@ -1782,6 +1798,14 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         }
+      }
+    },
+    "find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "requires": {
+        "array-back": "^3.0.1"
       }
     },
     "find-up": {
@@ -3025,6 +3049,11 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.find": {
       "version": "4.6.0",
@@ -5019,6 +5048,11 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "rluvaton",
   "license": "ISC",
   "dependencies": {
+    "command-line-args": "^5.1.1",
     "dotenv": "^8.1.0",
     "moment": "^2.24.0",
     "package-size": "^2.3.0",

--- a/src/common/platforms.js
+++ b/src/common/platforms.js
@@ -1,0 +1,43 @@
+/**
+ * @typedef {Platforms.NPM | Platforms.GO | Platforms.PACKAGIST | Platforms.PYPI | Platforms.MAVEN | Platforms.NUGET | Platforms.RUBYGEMS | Platforms.BOWER | Platforms.WORD_PRESS | Platforms.COCOA_PODS | Platforms.CPAN | Platforms.CARGO | Platforms.CLOJARS | Platforms.CRAN | Platforms.HACKAGE | Platforms.METEOR | Platforms.ATOM | Platforms.HEX | Platforms.PUB | Platforms.PLATFORM_IO | Platforms.PUPPET | Platforms.EMACS | Platforms.HOMEBREW | Platforms.SWIFT_PM | Platforms.CARTHAGE | Platforms.JULIA | Platforms.SUBLIME | Platforms.DUB | Platforms.RACKET | Platforms.ELM | Platforms.HAXELIB | Platforms.NIMBLE | Platforms.ALCATRAZ | Platforms.PURE_SCRIPT | Platforms.INQLUDE} Platforms
+ */
+
+const Platforms = {
+    NPM: 'npm',
+    GO: 'Go',
+    PACKAGIST: 'Packagist',
+    PYPI: 'PyPI',
+    MAVEN: 'Maven',
+    NUGET: 'NuGet',
+    RUBYGEMS: 'Rubygems',
+    BOWER: 'Bower',
+    WORD_PRESS: 'WordPress',
+    COCOA_PODS: 'CocoaPods',
+    CPAN: 'CPAN',
+    CARGO: 'Cargo',
+    CLOJARS: 'Clojars',
+    CRAN: 'CRAN',
+    HACKAGE: 'Hackage',
+    METEOR: 'Meteor',
+    ATOM: 'Atom',
+    HEX: 'Hex',
+    PUB: 'Pub',
+    PLATFORM_IO: 'PlatformIO',
+    PUPPET: 'Puppet',
+    EMACS: 'Emacs',
+    HOMEBREW: 'Homebrew',
+    SWIFT_PM: 'SwiftPM',
+    CARTHAGE: 'Carthage',
+    JULIA: 'Julia',
+    SUBLIME: 'Sublime',
+    DUB: 'Dub',
+    RACKET: 'Racket',
+    ELM: 'Elm',
+    HAXELIB: 'Haxelib',
+    NIMBLE: 'Nimble',
+    ALCATRAZ: 'Alcatraz',
+    PURE_SCRIPT: 'PureScript',
+    INQLUDE: 'Inqlude'
+};
+
+module.exports = Platforms;

--- a/src/common/script-handle-option.js
+++ b/src/common/script-handle-option.js
@@ -1,0 +1,15 @@
+
+/**
+ * @typedef {ScriptHandleOptions.PRINT | ScriptHandleOptions.WRITE_TO_FILE} ScriptHandleOptions
+ */
+
+/**
+ * The options that have (should be added to the typedef of `ScriptHandleOptions`
+ */
+const ScriptHandleOptions = {
+    PRINT: 'print',
+    WRITE_TO_FILE: 'file'
+};
+
+module.exports = ScriptHandleOptions;
+

--- a/src/common/sort-options.js
+++ b/src/common/sort-options.js
@@ -1,0 +1,24 @@
+
+/**
+ * @typedef {SortOptions.RANK|SortOptions.STARS|SortOptions.DEPENDENTS_COUNT|SortOptions.DEPENDENT_REPOS_COUNT|SortOptions.LATEST_RELEASE_PUBLISHED_AT|SortOptions.CONTRIBUTIONS_COUNT|SortOptions.CREATED_AT} SortOptions
+ *
+ * SortOptions.RANK - By package rank
+ * SortOptions.STARS - By package stars
+ * SortOptions.DEPENDENTS_COUNT - By package Dependents Count
+ * SortOptions.DEPENDENT_REPOS_COUNT - By the count of dependent repos that depended on the package
+ * SortOptions.LATEST_RELEASE_PUBLISHED_AT- By package latest release date
+ * SortOptions.CONTRIBUTIONS_COUNT - By the count of contributions to this package package
+ * SortOptions.CREATED_AT - By package creation date
+ */
+
+const SortOptions = {
+    RANK: "rank",
+    STARS: "stars",
+    DEPENDENTS_COUNT: "dependents_count",
+    DEPENDENT_REPOS_COUNT: "dependent_repos_count",
+    LATEST_RELEASE_PUBLISHED_AT: "latest_release_published_at",
+    CONTRIBUTIONS_COUNT: "contributions_count",
+    CREATED_AT: "created_at"
+};
+
+module.exports = SortOptions;

--- a/src/libraries-api-handler.js
+++ b/src/libraries-api-handler.js
@@ -111,7 +111,7 @@ LibrariesAPIHandler.prototype = {};
 LibrariesAPIHandler.prototype._validateOptions = function (options) {
     if (!options) {
         throw {
-            message: 'Options can\'t be falsy'
+            message: 'UserOptions can\'t be falsy'
         };
     }
 
@@ -124,7 +124,7 @@ LibrariesAPIHandler.prototype._validateOptions = function (options) {
 
 /**
  * Get packages in platform
- * @param {GetPackagesInPlatformOptions} options Options like in which platform to take from how many packages and more
+ * @param {UserOptions} options UserOptions like in which platform to take from how many packages and more
  * @return {Promise<Array<Package>|Package[]>}
  */
 LibrariesAPIHandler.prototype.getPackagesInPlatform = async function (options) {
@@ -164,7 +164,7 @@ LibrariesAPIHandler.prototype.getPackagesInPlatform = async function (options) {
 /**
  * Get packages in specified page
  * @param {number} page Page to fetch packages from
- * @param {GetPackagesInPlatformOptions} options
+ * @param {UserOptions} options
  * @return {Promise<Array>} Packages of the wanted page
  */
 LibrariesAPIHandler.prototype._getPackagesInSinglePage = async function (page = 1, options) {
@@ -251,7 +251,7 @@ LibrariesAPIHandler.prototype._parsePackage = function (p) {
 
 /**
  * Create script for downloading the libraries that fetched
- * @param {string} selectedPlatform Platform that the packages data from
+ * @param {Platforms} selectedPlatform Platform that the packages data from
  * @param {Array<Package>|Package[]} packagesData
  * @return {string} download script
  */

--- a/src/options/options-from-program-args.js
+++ b/src/options/options-from-program-args.js
@@ -1,0 +1,100 @@
+// Parse command line arguments
+const commandLineArgs = require('command-line-args');
+
+const UserOptions = require('./user-options');
+
+const UserOptionKeys = UserOptions.OptionKeys;
+const DefaultUserOptions = UserOptions.default;
+
+// region Declaring Typing for JSDoc
+
+/**
+ * @typedef {Object} OptionsFromProgramArgs
+ * @property {function(*): Boolean} isArgsContainOptions
+ * @property {function(*): UserOptions} getUserOptionsFromProgramArgs
+ */
+
+// endregion
+
+/**
+ * Option Definition for `command-line-args` library
+ */
+const optionDefinitions = [
+    {
+        name: 'default',
+        alias: 'd',
+        type: Boolean,
+        defaultValue: false
+    },
+    {
+        name: 'set-options',
+        alias: 'o',
+        type: Boolean,
+        defaultValue: false
+    },
+    {
+        name: UserOptionKeys.TOTAL_PACKAGES,
+        type: Number,
+        defaultValue: DefaultUserOptions.totalPackages
+    },
+    {
+        name: UserOptionKeys.STARTING_PAGE,
+        type: Number,
+        defaultValue: DefaultUserOptions.startingPage
+    },
+    {
+        name: UserOptionKeys.SCRIPT_HANDLE_OPTION,
+        type: String,
+        defaultValue: DefaultUserOptions.scriptHandleOptions
+    },
+    {
+        name: UserOptionKeys.FILE_PATH,
+        type: String,
+        defaultValue: DefaultUserOptions.filePath
+    },
+    {
+        name: UserOptionKeys.PLATFORM,
+        alias: 'p',
+        type: String,
+        defaultValue: DefaultUserOptions.platform
+    },
+    {
+        name: UserOptionKeys.SORT_BY,
+        type: String,
+        defaultValue: DefaultUserOptions.sortBy
+    }
+];
+
+/**
+ * Options From Program Args handler
+ * @type {OptionsFromProgramArgs}
+ */
+const OptionsFromProgramArgs = {
+
+    isArgsContainOptions: (args) => {
+        let options;
+
+        try {
+            options = commandLineArgs(optionDefinitions);
+        } catch (e) {
+            console.error('Error at parsing program args');
+            console.error(e);
+            return false;
+        }
+
+        if (!options || Object.keys(options).length === 0) {
+            return false;
+        }
+
+        // Convert from falsy/truthy value to false/true
+        return !!(options.default || options['set-options']);
+    },
+
+    getUserOptionsFromProgramArgs: (args) => {
+        let options = commandLineArgs(optionDefinitions);
+
+        return new UserOptions(options.default ? {} : options);
+    }
+};
+
+module.exports = OptionsFromProgramArgs;

--- a/src/options/options-from-user-input.js
+++ b/src/options/options-from-user-input.js
@@ -1,0 +1,154 @@
+// Get input from user
+const prompts = require('prompts');
+
+const utils = require('../utils');
+
+const ScriptHandleOptions = require('../common/script-handle-option');
+const SortOptions = require('../common/sort-options');
+const Platforms = require('../common/platforms');
+
+const UserOptions = require('./user-options');
+
+const UserOptionKeys = UserOptions.OptionKeys;
+const DefaultUserOptions = UserOptions.default;
+
+
+const sortByChoices = [
+    {value: SortOptions.RANK, title: SortOptions.RANK},
+    {value: SortOptions.STARS, title: SortOptions.STARS},
+    {value: SortOptions.DEPENDENTS_COUNT, title: SortOptions.DEPENDENTS_COUNT},
+    {value: SortOptions.DEPENDENT_REPOS_COUNT, title: SortOptions.DEPENDENT_REPOS_COUNT},
+    {value: SortOptions.LATEST_RELEASE_PUBLISHED_AT, title: SortOptions.LATEST_RELEASE_PUBLISHED_AT},
+    {value: SortOptions.CONTRIBUTIONS_COUNT, title: SortOptions.CONTRIBUTIONS_COUNT},
+    {value: SortOptions.CREATED_AT, title: SortOptions.CREATED_AT}
+];
+
+const platformChoices = [
+    {value: Platforms.NPM, title: Platforms.NPM},
+    {value: Platforms.GO, title: Platforms.GO},
+    {value: Platforms.PACKAGIST, title: Platforms.PACKAGIST},
+    {value: Platforms.PYPI, title: Platforms.PYPI},
+    {value: Platforms.MAVEN, title: Platforms.MAVEN},
+    {value: Platforms.NUGET, title: Platforms.NUGET},
+    {value: Platforms.RUBYGEMS, title: Platforms.RUBYGEMS},
+    {value: Platforms.BOWER, title: Platforms.BOWER},
+    {value: Platforms.WORD_PRESS, title: Platforms.WORD_PRESS},
+    {value: Platforms.COCOA_PODS, title: Platforms.COCOA_PODS},
+    {value: Platforms.CPAN, title: Platforms.CPAN},
+    {value: Platforms.CARGO, title: Platforms.CARGO},
+    {value: Platforms.CLOJARS, title: Platforms.CLOJARS},
+    {value: Platforms.CRAN, title: Platforms.CRAN},
+    {value: Platforms.HACKAGE, title: Platforms.HACKAGE},
+    {value: Platforms.METEOR, title: Platforms.METEOR},
+    {value: Platforms.ATOM, title: Platforms.ATOM},
+    {value: Platforms.HEX, title: Platforms.HEX},
+    {value: Platforms.PUB, title: Platforms.PUB},
+    {value: Platforms.PLATFORM_IO, title: Platforms.PLATFORM_IO},
+    {value: Platforms.PUPPET, title: Platforms.PUPPET},
+    {value: Platforms.EMACS, title: Platforms.EMACS},
+    {value: Platforms.HOMEBREW, title: Platforms.HOMEBREW},
+    {value: Platforms.SWIFT_PM, title: Platforms.SWIFT_PM},
+    {value: Platforms.CARTHAGE, title: Platforms.CARTHAGE},
+    {value: Platforms.JULIA, title: Platforms.JULIA},
+    {value: Platforms.SUBLIME, title: Platforms.SUBLIME},
+    {value: Platforms.DUB, title: Platforms.DUB},
+    {value: Platforms.RACKET, title: Platforms.RACKET},
+    {value: Platforms.ELM, title: Platforms.ELM},
+    {value: Platforms.HAXELIB, title: Platforms.HAXELIB},
+    {value: Platforms.NIMBLE, title: Platforms.NIMBLE},
+    {value: Platforms.ALCATRAZ, title: Platforms.ALCATRAZ},
+    {value: Platforms.PURE_SCRIPT, title: Platforms.PURE_SCRIPT},
+    {value: Platforms.INQLUDE, title: Platforms.INQLUDE}
+];
+
+/**
+ * Get the index of the initial value in the choices
+ * @param {string} userOptionKey The
+ * @param {Array<{value: string|title: string}>|{value: string|title: string}[]} choices
+ * @return {number} Index of the initial choice
+ */
+function getInitialIndexFromChoicesAndName(userOptionKey, choices) {
+    const initialValue = UserOptions[userOptionKey];
+    return choices.findIndex((choice) => choice.value === initialValue);
+}
+
+const scriptHandleOptionsChoices = [
+    {title: 'Print it', value: ScriptHandleOptions.PRINT},
+    {title: 'Write to file', value: ScriptHandleOptions.WRITE_TO_FILE},
+];
+
+const OptionsFromUserInput = {
+    /**
+     * {prompts.PromptObject<T> | Array<prompts.PromptObject<T>>} Configuration questions
+     */
+    questions: [
+        {
+            type: 'number',
+            name: UserOptionKeys.TOTAL_PACKAGES,
+            message: 'How many packages do you want?',
+            initial: DefaultUserOptions[UserOptionKeys.TOTAL_PACKAGES],
+            min: 1
+        },
+        {
+            type: 'number',
+            name: UserOptionKeys.STARTING_PAGE,
+            message: 'From which page do you wanna start? (default is 1)',
+            initial: false,
+            min: 1
+        },
+        {
+            type: 'confirm',
+            name: UserOptionKeys.ADVANCE_OPTIONS,
+            message: 'Enter advance options?',
+            initial: DefaultUserOptions[UserOptionKeys.ADVANCE_OPTIONS]
+        },
+        {
+            type: (prev, values) => values[UserOptionKeys.ADVANCE_OPTIONS] ? 'select' : null,
+            name: UserOptionKeys.SCRIPT_HANDLE_OPTION,
+            message: 'How do you want to handle the script?',
+            choices: scriptHandleOptionsChoices,
+            initial: getInitialIndexFromChoicesAndName(UserOptionKeys.SCRIPT_HANDLE_OPTION, scriptHandleOptionsChoices),
+        },
+        {
+            type: (prev) => prev === ScriptHandleOptions.WRITE_TO_FILE ? 'text' : null,
+            name: UserOptionKeys.FILE_PATH,
+            message: 'Please Enter the file path you want to add',
+            initial: DefaultUserOptions[UserOptionKeys.FILE_PATH],
+            validate: (filePath) => {
+                if (!filePath) {
+                    return false;
+                }
+
+                if (utils.isPathExist(filePath)) {
+                    return utils.validatePathType(filePath, true);
+                }
+
+                return utils.isParentFolderExist(path);
+            }
+        },
+        {
+            type: (prev, values) => values[UserOptionKeys.ADVANCE_OPTIONS] ? 'select' : null,
+            name: UserOptionKeys.PLATFORM,
+            message: 'Choose platform',
+            choices: platformChoices,
+            initial: getInitialIndexFromChoicesAndName(UserOptionKeys.PLATFORM, platformChoices),
+        },
+        {
+            type: (prev, values) => values[UserOptionKeys.ADVANCE_OPTIONS] ? 'select' : null,
+            name: UserOptionKeys.SORT_BY,
+            message: 'Choose what is the sort parameter',
+            choices: sortByChoices,
+            initial: getInitialIndexFromChoicesAndName(UserOptionKeys.SORT_BY, sortByChoices),
+        }
+    ],
+
+    /**
+     * Get Options from input
+     * @return {Promise<UserOptions>}
+     */
+    getOptionsFromInput() {
+        return prompts(this.questions).then((options) => new UserOptions(options));
+    }
+};
+
+module.exports = OptionsFromUserInput;

--- a/src/options/user-options-handler.js
+++ b/src/options/user-options-handler.js
@@ -1,0 +1,21 @@
+const utils = require('../utils');
+
+const OptionsFromProgramArgs = require('./options-from-program-args');
+const OptionsFromUserInput = require('./options-from-user-input');
+
+const UserOptionsHandler = {
+
+    /**
+     * Get user options
+     * @return {Promise<UserOptions>}
+     */
+    getUserOptions: async function (programArgs) {
+        let options = (OptionsFromProgramArgs.isArgsContainOptions(programArgs))
+            ? OptionsFromProgramArgs.getUserOptionsFromProgramArgs(programArgs)
+            : OptionsFromUserInput.getOptionsFromInput().catch(utils.defaultErrorHandling);
+
+        return Promise.resolve(options);
+    },
+};
+
+module.exports = UserOptionsHandler;

--- a/src/options/user-options.js
+++ b/src/options/user-options.js
@@ -1,0 +1,135 @@
+const ScriptHandleOptions = require('../common/script-handle-option');
+const Platforms = require('../common/platforms');
+const SortOptions = require('../common/sort-options');
+
+// region Declaring Typing for JSDoc
+
+/**
+ * @typedef {Object} UserOptions
+ * @property {number} totalPackages - Total packages to fetch
+ * @property {number} startingPage - From which page to start fetching packages
+ * @property {ScriptHandleOptions} scriptHandleOptions - How to handle the script
+ * @property {string} filePath - File path in case that `file` is chosen in `scriptHandleOptions` option
+ * @property {Platforms} platform - Platform to get the packages from
+ * @property {SortOptions} sortBy - at which order to get the packages (i.e get from npm the packages with the top dependents count)
+ */
+
+// endregion
+
+/**
+ * Keys of the `UserOptions`
+ * @type {{PLATFORM: string, TOTAL_PACKAGES: string, SORT_BY: string, ADVANCE_OPTIONS: string, SCRIPT_HANDLE_OPTION: string, STARTING_PAGE: string, FILE_PATH: string}}
+ */
+const OptionKeys = {
+    TOTAL_PACKAGES: 'totalPackages',
+    STARTING_PAGE: 'startingPage',
+    ADVANCE_OPTIONS: 'advanceOptions',
+    SCRIPT_HANDLE_OPTION: 'scriptHandleOption',
+    FILE_PATH: 'filePath',
+    PLATFORM: 'platform',
+    SORT_BY: 'sortBy'
+};
+
+const defaultOptions = {
+    [OptionKeys.TOTAL_PACKAGES]: 100,
+    [OptionKeys.STARTING_PAGE]: 1,
+    [OptionKeys.ADVANCE_OPTIONS]: false,
+    [OptionKeys.SCRIPT_HANDLE_OPTION]: ScriptHandleOptions.WRITE_TO_FILE,
+    [OptionKeys.FILE_PATH]: './packages-download-script.bat',
+    [OptionKeys.PLATFORM]: Platforms.NPM,
+    [OptionKeys.SORT_BY]: SortOptions.DEPENDENTS_COUNT
+};
+
+/**
+ * @param {*} options UserOptions
+ * @param {boolean} setEmptyOptionsAsDefault Set the the empty options as default
+ * @constructor
+ */
+function UserOptions(options, setEmptyOptionsAsDefault = true) {
+    options = options || {};
+
+    /**
+     * Total packages to fetch
+     * @type {number}
+     * @default 100
+     */
+    this.totalPackages = options.totalPackages;
+
+    /**
+     * From which page to start fetching packages
+     * @type {number}
+     * @default 1
+     */
+    this.startingPage = options.startingPage;
+
+    /**
+     * How to handle the script
+     * @type {ScriptHandleOptions}
+     * @default ScriptHandleOptions.WRITE_TO_FILE
+     */
+    this.scriptHandleOptions = options.scriptHandleOptions;
+
+    /**
+     * File path in case that `file` is chosen in `scriptHandleOptions` option
+     * @type {string}
+     * @default './packages-download-script.bat'
+     */
+    this.filePath = options.filePath;
+
+    /**
+     * Platform to get the packages from
+     * @type {Platforms}
+     * @default PlatformOptions.NPM
+     */
+    this.platform = options.platform;
+
+    /**
+     * At which order to get the packages (i.e get from npm the packages with the top dependents count)
+     * @type {SortOptions}
+     * @default SortOptions.DEPENDENTS_COUNT
+     */
+    this.sortBy = options.sortBy;
+
+    if (setEmptyOptionsAsDefault) {
+        this.setEmptyOptionsAsDefault();
+    }
+}
+
+UserOptions.prototype = {};
+
+/**
+ * Set the the empty options as default
+ */
+UserOptions.prototype.setEmptyOptionsAsDefault = function () {
+    this.totalPackages = this.totalPackages > 0 ? this.totalPackages : defaultOptions[OptionKeys.TOTAL_PACKAGES];
+    this.startingPage = this.startingPage > 0 ? this.startingPage : defaultOptions[OptionKeys.STARTING_PAGE];
+    this.scriptHandleOptions = this.scriptHandleOptions || defaultOptions[OptionKeys.SCRIPT_HANDLE_OPTION];
+    this.filePath = this.filePath || defaultOptions[OptionKeys.FILE_PATH];
+    this.platform = this.platform || defaultOptions[OptionKeys.PLATFORM];
+    this.sortBy = this.sortBy || defaultOptions[OptionKeys.SORT_BY];
+};
+
+/**
+ * UserOptions properties in string
+ * @type {OptionKeys}
+ *
+ * Making the `OptionKeys` value readonly
+ */
+Object.defineProperty(UserOptions, "OptionKeys", {
+    value: OptionKeys,
+    writable: false
+});
+
+/**
+ * Default User Options
+ * @type {UserOptions}
+ *
+ * Making the `default` value readonly
+ */
+Object.defineProperty(UserOptions, "default", {
+    value: new UserOptions(null),
+    writable: false
+});
+
+module.exports = UserOptions;
+

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,94 +1,182 @@
-
 // HTTP library
 const request = require("request");
 
 // Library for utils functions for date & time
 const moment = require('moment');
 
-/**
- * Parse bytes to human readable text
- * @param {number} bytes
- * @param {boolean} si SI prefix (i.e si = true is GB | si = false is GiB)
- * @return {string} The size in readable text
- *
- * @example si = true
- * parseBytesToHumanReadable(32000000, true)
- * // returns '32.0 MB'
- *
- * @example si = false
- * parseBytesToHumanReadable(32000000, false)
- * // returns '30.5 MiB'
- */
-function parseBytesToHumanReadable(bytes, si) {
-    const thresh = si ? 1000 : 1024;
-    if (Math.abs(bytes) < thresh) {
-        return bytes + ' B';
-    }
+// File System
+const fs = require("fs");
 
-    const units = si
-        ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
-        : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
-    let u = -1;
+const Utils = {
 
-    do {
-        bytes /= thresh;
-        ++u;
-    } while (Math.abs(bytes) >= thresh && u < units.length - 1);
+    /**
+     * Parse bytes to human readable text
+     * @param {number} bytes
+     * @param {boolean} si SI prefix (i.e si = true is GB | si = false is GiB)
+     * @return {string} The size in readable text
+     *
+     * @example si = true
+     * parseBytesToHumanReadable(32000000, true)
+     * // returns '32.0 MB'
+     *
+     * @example si = false
+     * parseBytesToHumanReadable(32000000, false)
+     * // returns '30.5 MiB'
+     */
+    parseBytesToHumanReadable: function (bytes, si = false) {
+        const thresh = si ? 1000 : 1024;
+        if (Math.abs(bytes) < thresh) {
+            return bytes + ' B';
+        }
 
-    return `${bytes.toFixed(1)} ${units[u]}`;
-}
+        const units = si
+            ? ['kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+            : ['KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
+        let u = -1;
 
-/**
- * Return promise that resolve after the milliseconds that provided passed
- * @param {number} ms Milliseconds to sleep
- * @return {Promise} Waiting promise
- */
-function sleep(ms) {
-    return new Promise(resolve => {
-        setTimeout(resolve, ms);
-    });
-}
+        do {
+            bytes /= thresh;
+            ++u;
+        } while (Math.abs(bytes) >= thresh && u < units.length - 1);
 
-/**
- * Create `request` call that return promise - resolve with the data or rejected with the error
- * @param options Options for the request
- * @param {boolean} getBody If the promise should return the body or the whole request
- * @return {Promise} The response body / response as promise
- */
-function requestWithPromise(options, getBody = true) {
-    return new Promise((resolve, reject) => {
-        request(options, (error, response, body) => {
-            if (error) {
-                reject(error);
-                return;
-            }
+        return `${bytes.toFixed(1)} ${units[u]}`;
+    },
 
-            resolve(getBody ? body : response);
+    /**
+     * Return promise that resolve after the milliseconds that provided passed
+     * @param {number} ms Milliseconds to sleep
+     * @return {Promise} Waiting promise
+     */
+    sleep: function (ms) {
+        return new Promise(resolve => {
+            setTimeout(resolve, ms);
         });
-    });
-}
+    },
 
-/**
- * The default error handling
- * @param err Error that raised
- */
-function defaultErrorHandling(err) {
-    console.error(err);
-}
+    /**
+     * Create `request` call that return promise - resolve with the data or rejected with the error
+     * @param options UserOptions for the request
+     * @param {boolean} getBody If the promise should return the body or the whole request
+     * @return {Promise} The response body / response as promise
+     */
+    requestWithPromise: function (options, getBody = true) {
+        return new Promise((resolve, reject) => {
+            request(options, (error, response, body) => {
+                if (error) {
+                    reject(error);
+                    return;
+                }
 
-/**
- * Get the UTC timestamp (as milliseconds) from date & time string
- * @param {string} date
- * @return {number} UTC timestamp in milliseconds
- */
-function getUTCTimestampFromDateStr(date) {
-    return moment(date).utc().valueOf()
-}
+                resolve(getBody ? body : response);
+            });
+        });
+    },
 
-module.exports = {
-    parseBytesToHumanReadable,
-    sleep,
-    requestWithPromise,
-    getUTCTimestampFromDateStr,
-    defaultErrorHandling
+    /**
+     * The default error handling
+     * @param err Error that raised
+     */
+    defaultErrorHandling: function (err) {
+        console.error(err);
+    },
+
+    /**
+     * Get the UTC timestamp (as milliseconds) from date & time string
+     * @param {string} date
+     * @return {number} UTC timestamp in milliseconds
+     */
+    getUTCTimestampFromDateStr: function (date) {
+        return moment(date).utc().valueOf()
+    },
+
+    validatePath: function (path) {
+
+        // 1 - if path exist
+        // 1.1 true: if path is file
+        // 1.1.1 true: GOOD
+        // 1.1.1 false: BAD
+        // 1.1 false: if parent folder exist:
+        // 1.1.1 true: GOOD
+        // 1.1.1 false: BAD
+
+        if (isPathExist(path)) {
+            return isPathAFile(path);
+        }
+
+        return isParentFolderExist(path);
+    },
+
+    /**
+     * Check if path exist
+     * @param {string} path File/Directory Path to test
+     * @return {boolean} file/directory existence
+     */
+    isPathExist: function (path) {
+        return fs.existsSync(path);
+    },
+
+    /**
+     * Check if parent folder of file/folder exists
+     * @param {string} path Path to file/directory
+     * @return {boolean} If parent folder existence
+     */
+    isParentFolderExist: function (path) {
+        if (!path) {
+            return false;
+        }
+
+        // If already a path
+        if (path.endsWith('\\') || path.endsWith('/')) {
+            path = path.slice(0, -1);
+        }
+
+        let lastSlashIndex = Math.max(path.lastIndexOf('\\'), path.lastIndexOf('/'));
+
+        const parentPath = lastSlashIndex !== -1 ? path.substr(0, lastSlashIndex) : path;
+        return fs.existsSync(parentPath);
+    },
+
+    /**
+     * Validate path to be file or folder
+     * @param {string} path Path to validate
+     * @param {boolean} isFileType True to compare with file type, false for checking if directory
+     * @return {boolean} If the type of a path is like `isFileType` value (true: file, false: folder)
+     */
+    validatePathType: function (path, isFileType) {
+        const pathStat = fs.lstatSync(path);
+        return isFileType ? pathStat.isFile() : pathStat.isDirectory();
+    },
+
+    /**
+     * Write to file the content (Overwrite if already exist)
+     * @param {string} path Path to file
+     * @param content content to write in the file
+     * @return {Promise}
+     */
+    writeFile: function(path, content) {
+        return new Promise((resolve, reject) => {
+            fs.writeFile(path, content, (err) => {
+                if(err) {
+                    reject(err);
+                    return;
+                }
+
+                resolve();
+            });
+        });
+    },
+
+    /**
+     * Check if value is either `null` or `undefined`
+     * @param value Value to check
+     * @return {boolean} The result if the value is nil
+     */
+    isNil: function (value) {
+        // from SO answer - https://stackoverflow.com/a/5515385/5923666
+        return value == null;
+    }
 };
+
+// isValidFilePath
+
+module.exports = Utils;


### PR DESCRIPTION
- Add write to file option (now it's the default option for script handling)
- Add option to add program arguments instead #1 

- Split to different files the constants options (`platforms`, `sortOptions` and `scriptHandleOption`)
- Split to files for handling the user option